### PR TITLE
Ensure Python 3.8 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 ## Установка
 ```bash
-python3.9 -m venv .venv
+python3.8 -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt
 ```

--- a/examples/tutorial.ipynb
+++ b/examples/tutorial.ipynb
@@ -125,7 +125,7 @@
   },
   "language_info": {
    "name": "python",
-   "version": "3.9"
+   "version": "3.8"
   }
  },
  "nbformat": 4,

--- a/genrest/genetic_stratifier.py
+++ b/genrest/genetic_stratifier.py
@@ -7,7 +7,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 import numpy as np
 import pandas as pd
@@ -57,7 +57,7 @@ class GeneticStratifier:
         generations: int = 50,
         mutation_rate: float = 0.1,
         n_groups: int = 3,
-        random_state: int | None = None,
+        random_state: Optional[int] = None,
     ) -> None:
         self.strat_columns = strat_columns
         self.target_col = target_col


### PR DESCRIPTION
## Summary
- replace Python 3.10 union syntax with `Optional[int]`
- document Python 3.8 usage in README and tutorial notebook

## Testing
- `python -m pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement numpy>=1.20)*
- `python -m py_compile genrest/genetic_stratifier.py genrest/binning.py genrest/__init__.py examples/run_example.py`
- `python examples/run_example.py` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68b9608baadc833286d9d23ea1b38c82