### PR TITLE
Update tutorial data to highlight variance reduction

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,27 +73,37 @@ import numpy as np
 import pandas as pd
 from genrest import GeneticStratificationAlgorithm, bin_numeric
 
-# синтетические данные
-data = pd.DataFrame({
-    "color": np.random.choice(["red", "blue", "green"], 200),
-    "shape": np.random.choice(["circle", "square", "triangle"], 200),
-    "age": np.random.normal(30, 10, 200),
-})
-# целевая переменная зависит от признаков
 rng = np.random.default_rng(0)
-data["y"] = ((data["color"] == "red").astype(int)
-             + (data["shape"] == "circle").astype(int)
-             + data["age"] / 10
-             + rng.normal(0, 1, len(data)))
+data = pd.DataFrame({
+    "color": rng.choice(["ruby", "amber", "teal"], size=600, p=[0.45, 0.35, 0.2]),
+    "shape": rng.choice(["circle", "square", "triangle"], size=600, p=[0.4, 0.4, 0.2]),
+    "age": rng.normal(42, 11, size=600),
+})
 
-# превращаем age в категории
-bin_numeric(data, "age", bins=3)
+color_effect = np.select(
+    [data["color"] == "ruby", data["color"] == "amber"],
+    [4.5, 2.0],
+    default=-1.5,
+)
+shape_effect = np.select(
+    [data["shape"] == "circle", data["shape"] == "square"],
+    [3.0, -0.5],
+    default=-2.0,
+)
+age_effect = np.select(
+    [data["age"] < 35, data["age"] < 45, data["age"] < 55],
+    [-1.0, 0.5, 2.0],
+    default=3.2,
+)
+data["y"] = color_effect + shape_effect + age_effect + rng.normal(0, 0.4, len(data))
+
+bin_numeric(data, "age", bins=4)
 
 stratifier = GeneticStratificationAlgorithm(
     strat_columns=["color", "shape", "age"],
     target_col="y",
-    population_size=10,
-    generations=5,
+    population_size=25,
+    generations=40,
     total_strata=8,
     random_state=0,
 )
@@ -102,7 +112,6 @@ best = stratifier.fit(data)
 print(best)
 print("score:", stratifier.best_score_)
 
-# преобразуем категории в информативную метку страты
 stratified = stratifier.transform(data, column_name="strata")
 print(stratified.head())
 ```
@@ -114,7 +123,11 @@ print(stratified.head())
 * стратифицированную дисперсию после объединения категорий генетическим алгоритмом;
 * процент понижения стратифицированной дисперсии относительно исходной (если
   понижения нет, библиотека сообщает об отсутствии эффекта и выводит размер
-  роста).
+  роста). Показатель сравнивает страты до и после объединения категорий: при
+  жёстком сжатии количества страт новое значение может быть выше, хотя
+  стратификация всё равно радикально уменьшает дисперсию по сравнению с
+  «сырыми» данными. Для оценки эффекта удобно дополнительно сравнить
+  `overall_var` (печатается первой строкой) с метрикой алгоритма.
 
 Это помогает сразу понять эффект от объединения страт без дополнительных расчётов.
 
@@ -132,8 +145,8 @@ algo = InheritedGeneticStratificationAlgorithm(
     target_col="y",
     mandatory_columns=["color"],
     n_groups=2,
-    generations=5,
-    population_size=10,
+    generations=40,
+    population_size=25,
 )
 algo.fit(data)
 collapsed = algo.transform(data)

--- a/examples/tutorial.ipynb
+++ b/examples/tutorial.ipynb
@@ -6,10 +6,10 @@
    "id": "54fe39b4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-10-22T14:47:58.050207Z",
-     "iopub.status.busy": "2025-10-22T14:47:58.049912Z",
-     "iopub.status.idle": "2025-10-22T14:47:58.056050Z",
-     "shell.execute_reply": "2025-10-22T14:47:58.054863Z"
+     "iopub.execute_input": "2025-10-22T15:41:04.663141Z",
+     "iopub.status.busy": "2025-10-22T15:41:04.662842Z",
+     "iopub.status.idle": "2025-10-22T15:41:04.670326Z",
+     "shell.execute_reply": "2025-10-22T15:41:04.668245Z"
     }
    },
    "outputs": [],
@@ -28,10 +28,7 @@
    "source": [
     "# Генетическая стратификация\n",
     "\n",
-    "Этот ноутбук показывает, как использовать взаимозаменяемые алгоритмы **GenRest**.\n",
-    "Мы создадим синтетические данные с категориальными и числовыми\n",
-    "признаками, преобразуем числовой признак в категории, а затем\n",
-    "запустим `GeneticStratificationAlgorithm`."
+    "Этот ноутбук показывает, как использовать взаимозаменяемые алгоритмы **GenRest** на синтетическом наборе из 600 наблюдений. Мы зададим выраженные зависимости между цветом, формой и возрастом, преобразуем возраст в категории, а затем запустим `GeneticStratificationAlgorithm`, чтобы увидеть заметное снижение дисперсии по сравнению с «сырыми» данными."
    ]
   },
   {
@@ -40,10 +37,10 @@
    "id": "b77f4238",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-10-22T14:47:58.058938Z",
-     "iopub.status.busy": "2025-10-22T14:47:58.058676Z",
-     "iopub.status.idle": "2025-10-22T14:47:58.501285Z",
-     "shell.execute_reply": "2025-10-22T14:47:58.500402Z"
+     "iopub.execute_input": "2025-10-22T15:41:04.673724Z",
+     "iopub.status.busy": "2025-10-22T15:41:04.673406Z",
+     "iopub.status.idle": "2025-10-22T15:41:05.307820Z",
+     "shell.execute_reply": "2025-10-22T15:41:05.306269Z"
     }
    },
    "outputs": [
@@ -77,50 +74,50 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>green</td>\n",
+       "      <td>amber</td>\n",
        "      <td>circle</td>\n",
-       "      <td>24.143422</td>\n",
-       "      <td>2.318870</td>\n",
+       "      <td>53.904412</td>\n",
+       "      <td>7.018824</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>blue</td>\n",
+       "      <td>ruby</td>\n",
        "      <td>square</td>\n",
-       "      <td>25.274123</td>\n",
-       "      <td>2.889915</td>\n",
+       "      <td>56.275646</td>\n",
+       "      <td>6.974324</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>blue</td>\n",
-       "      <td>circle</td>\n",
-       "      <td>35.863373</td>\n",
-       "      <td>5.030329</td>\n",
+       "      <td>ruby</td>\n",
+       "      <td>square</td>\n",
+       "      <td>47.098692</td>\n",
+       "      <td>5.598500</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td>red</td>\n",
-       "      <td>circle</td>\n",
-       "      <td>23.364648</td>\n",
-       "      <td>3.976025</td>\n",
+       "      <td>ruby</td>\n",
+       "      <td>square</td>\n",
+       "      <td>35.296698</td>\n",
+       "      <td>4.552813</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td>red</td>\n",
-       "      <td>triangle</td>\n",
-       "      <td>23.865822</td>\n",
-       "      <td>3.970116</td>\n",
+       "      <td>teal</td>\n",
+       "      <td>square</td>\n",
+       "      <td>35.910173</td>\n",
+       "      <td>-1.725747</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "   color     shape        age         y\n",
-       "0  green    circle  24.143422  2.318870\n",
-       "1   blue    square  25.274123  2.889915\n",
-       "2   blue    circle  35.863373  5.030329\n",
-       "3    red    circle  23.364648  3.976025\n",
-       "4    red  triangle  23.865822  3.970116"
+       "   color   shape        age         y\n",
+       "0  amber  circle  53.904412  7.018824\n",
+       "1   ruby  square  56.275646  6.974324\n",
+       "2   ruby  square  47.098692  5.598500\n",
+       "3   ruby  square  35.296698  4.552813\n",
+       "4   teal  square  35.910173 -1.725747"
       ]
      },
      "execution_count": 2,
@@ -138,11 +135,35 @@
     ")\n",
     "\n",
     "rng = np.random.default_rng(0)\n",
-    "colors = rng.choice(['red', 'blue', 'green'], size=200)\n",
-    "shapes = rng.choice(['circle', 'square', 'triangle'], size=200)\n",
-    "age = rng.normal(30, 10, size=200)\n",
-    "y = ((colors == 'red').astype(int) + (shapes == 'circle').astype(int) + age / 10 + rng.normal(0, 1, 200))\n",
-    "data = pd.DataFrame({'color': colors, 'shape': shapes, 'age': age, 'y': y})\n",
+    "colors = rng.choice([\"ruby\", \"amber\", \"teal\"], size=600, p=[0.45, 0.35, 0.2])\n",
+    "shapes = rng.choice([\"circle\", \"square\", \"triangle\"], size=600, p=[0.4, 0.4, 0.2])\n",
+    "age = rng.normal(42, 11, size=600)\n",
+    "\n",
+    "color_effect = np.select(\n",
+    "    [colors == \"ruby\", colors == \"amber\"],\n",
+    "    [4.5, 2.0],\n",
+    "    default=-1.5,\n",
+    ")\n",
+    "shape_effect = np.select(\n",
+    "    [shapes == \"circle\", shapes == \"square\"],\n",
+    "    [3.0, -0.5],\n",
+    "    default=-2.0,\n",
+    ")\n",
+    "age_effect = np.select(\n",
+    "    [age < 35, age < 45, age < 55],\n",
+    "    [-1.0, 0.5, 2.0],\n",
+    "    default=3.2,\n",
+    ")\n",
+    "\n",
+    "y = color_effect + shape_effect + age_effect + rng.normal(0, 0.4, size=600)\n",
+    "\n",
+    "data = pd.DataFrame({\n",
+    "    \"color\": colors,\n",
+    "    \"shape\": shapes,\n",
+    "    \"age\": age,\n",
+    "    \"y\": y,\n",
+    "})\n",
+    "\n",
     "data.head()"
    ]
   },
@@ -151,7 +172,7 @@
    "id": "c7fd183c",
    "metadata": {},
    "source": [
-    "Преобразуем числовой столбец `age` в категории с помощью функции `bin_numeric` и посмотрим на результат."
+    "Преобразуем числовой столбец `age` в четыре категории с помощью функции `bin_numeric` и посмотрим на результат."
    ]
   },
   {
@@ -160,10 +181,10 @@
    "id": "1ba99661",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-10-22T14:47:58.503947Z",
-     "iopub.status.busy": "2025-10-22T14:47:58.503529Z",
-     "iopub.status.idle": "2025-10-22T14:47:58.517425Z",
-     "shell.execute_reply": "2025-10-22T14:47:58.515867Z"
+     "iopub.execute_input": "2025-10-22T15:41:05.311734Z",
+     "iopub.status.busy": "2025-10-22T15:41:05.311156Z",
+     "iopub.status.idle": "2025-10-22T15:41:05.330735Z",
+     "shell.execute_reply": "2025-10-22T15:41:05.329503Z"
     }
    },
    "outputs": [
@@ -197,50 +218,50 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>green</td>\n",
+       "      <td>amber</td>\n",
        "      <td>circle</td>\n",
-       "      <td>(-7.724, 24.159]</td>\n",
-       "      <td>2.318870</td>\n",
+       "      <td>(49.913, 72.161]</td>\n",
+       "      <td>7.018824</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>blue</td>\n",
+       "      <td>ruby</td>\n",
        "      <td>square</td>\n",
-       "      <td>(24.159, 32.989]</td>\n",
-       "      <td>2.889915</td>\n",
+       "      <td>(49.913, 72.161]</td>\n",
+       "      <td>6.974324</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>blue</td>\n",
-       "      <td>circle</td>\n",
-       "      <td>(32.989, 60.66]</td>\n",
-       "      <td>5.030329</td>\n",
+       "      <td>ruby</td>\n",
+       "      <td>square</td>\n",
+       "      <td>(42.273, 49.913]</td>\n",
+       "      <td>5.598500</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td>red</td>\n",
-       "      <td>circle</td>\n",
-       "      <td>(-7.724, 24.159]</td>\n",
-       "      <td>3.976025</td>\n",
+       "      <td>ruby</td>\n",
+       "      <td>square</td>\n",
+       "      <td>(33.789, 42.273]</td>\n",
+       "      <td>4.552813</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td>red</td>\n",
-       "      <td>triangle</td>\n",
-       "      <td>(-7.724, 24.159]</td>\n",
-       "      <td>3.970116</td>\n",
+       "      <td>teal</td>\n",
+       "      <td>square</td>\n",
+       "      <td>(33.789, 42.273]</td>\n",
+       "      <td>-1.725747</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "   color     shape               age         y\n",
-       "0  green    circle  (-7.724, 24.159]  2.318870\n",
-       "1   blue    square  (24.159, 32.989]  2.889915\n",
-       "2   blue    circle   (32.989, 60.66]  5.030329\n",
-       "3    red    circle  (-7.724, 24.159]  3.976025\n",
-       "4    red  triangle  (-7.724, 24.159]  3.970116"
+       "   color   shape               age         y\n",
+       "0  amber  circle  (49.913, 72.161]  7.018824\n",
+       "1   ruby  square  (49.913, 72.161]  6.974324\n",
+       "2   ruby  square  (42.273, 49.913]  5.598500\n",
+       "3   ruby  square  (33.789, 42.273]  4.552813\n",
+       "4   teal  square  (33.789, 42.273] -1.725747"
       ]
      },
      "execution_count": 3,
@@ -249,7 +270,7 @@
     }
    ],
    "source": [
-    "bin_numeric(data, 'age', bins=3)\n",
+    "bin_numeric(data, 'age', bins=4)\n",
     "data.head()"
    ]
   },
@@ -258,7 +279,7 @@
    "id": "2c35407e",
    "metadata": {},
    "source": [
-    "Теперь запустим генетический алгоритм. В качестве параметра `n_groups` укажем 2, чтобы получить 2^3=8 страт."
+    "Теперь запустим генетический алгоритм. За счёт `n_groups=2` получаем 2^3=8 страт, а более длинная эволюция (`population_size=25`, `generations=40`) помогает устойчиво находить решение с минимальной дисперсией."
    ]
   },
   {
@@ -267,18 +288,18 @@
    "id": "14f9e231",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-10-22T14:47:58.520046Z",
-     "iopub.status.busy": "2025-10-22T14:47:58.519799Z",
-     "iopub.status.idle": "2025-10-22T14:47:58.657084Z",
-     "shell.execute_reply": "2025-10-22T14:47:58.655587Z"
+     "iopub.execute_input": "2025-10-22T15:41:05.334143Z",
+     "iopub.status.busy": "2025-10-22T15:41:05.333755Z",
+     "iopub.status.idle": "2025-10-22T15:41:08.256270Z",
+     "shell.execute_reply": "2025-10-22T15:41:08.255019Z"
     }
    },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "(Stratification(boundaries={'color': {'blue': 1, 'green': 1, 'red': 0}, 'shape': {'circle': 0, 'square': 1, 'triangle': 1}, 'age': {'(-7.724, 24.159]': 0, '(24.159, 32.989]': 1, '(32.989, 60.66]': 1}}),\n",
-       " 0.26765792014745565)"
+       "(Stratification(boundaries={'color': {'amber': 1, 'ruby': 0, 'teal': 1}, 'shape': {'circle': 0, 'square': 1, 'triangle': 1}, 'age': {'(33.789, 42.273]': 1, '(42.273, 49.913]': 0, '(49.913, 72.161]': 1, '(7.739, 33.789]': 0}}),\n",
+       " 0.4990934492798214)"
       ]
      },
      "execution_count": 4,
@@ -290,8 +311,8 @@
     "stratifier = GeneticStratificationAlgorithm(\n",
     "    strat_columns=['color', 'shape', 'age'],\n",
     "    target_col='y',\n",
-    "    population_size=10,\n",
-    "    generations=5,\n",
+    "    population_size=25,\n",
+    "    generations=40,\n",
     "    n_groups=2,\n",
     "    random_state=0,\n",
     ")\n",
@@ -315,10 +336,10 @@
    "id": "32e3b4fc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-10-22T14:47:58.659359Z",
-     "iopub.status.busy": "2025-10-22T14:47:58.659163Z",
-     "iopub.status.idle": "2025-10-22T14:47:58.679277Z",
-     "shell.execute_reply": "2025-10-22T14:47:58.678239Z"
+     "iopub.execute_input": "2025-10-22T15:41:08.260813Z",
+     "iopub.status.busy": "2025-10-22T15:41:08.259681Z",
+     "iopub.status.idle": "2025-10-22T15:41:08.293586Z",
+     "shell.execute_reply": "2025-10-22T15:41:08.292570Z"
     }
    },
    "outputs": [
@@ -328,10 +349,10 @@
      "text": [
       "\n",
       "Результаты трансформации:\n",
-      "  Цельная дисперсия: 2.536092\n",
-      "  Стратифицированная дисперсия по исходным комбинациям: 0.054331\n",
-      "  Стратифицированная дисперсия после объединения категорий: 0.267658\n",
-      "  Стратифицированная дисперсия по сравнению с исходной: понижения нет (рост на 392.64% относительно исходной стратифицированной дисперсии)\n"
+      "  Цельная дисперсия: 11.283086\n",
+      "  Стратифицированная дисперсия по исходным комбинациям: 0.013610\n",
+      "  Стратифицированная дисперсия после объединения категорий: 0.499093\n",
+      "  Стратифицированная дисперсия по сравнению с исходной: понижения нет (рост на 3567.24% относительно исходной стратифицированной дисперсии)\n"
      ]
     },
     {
@@ -362,28 +383,28 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>2.318870</td>\n",
-       "      <td>strata_4: color={blue, green}; shape={circle};...</td>\n",
+       "      <td>7.018824</td>\n",
+       "      <td>strata_5: color={amber, teal}; shape={circle};...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>2.889915</td>\n",
-       "      <td>strata_7: color={blue, green}; shape={square, ...</td>\n",
+       "      <td>6.974324</td>\n",
+       "      <td>strata_3: color={ruby}; shape={square, triangl...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>5.030329</td>\n",
-       "      <td>strata_5: color={blue, green}; shape={circle};...</td>\n",
+       "      <td>5.598500</td>\n",
+       "      <td>strata_2: color={ruby}; shape={square, triangl...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td>3.976025</td>\n",
-       "      <td>strata_0: color={red}; shape={circle}; age={(-...</td>\n",
+       "      <td>4.552813</td>\n",
+       "      <td>strata_3: color={ruby}; shape={square, triangl...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td>3.970116</td>\n",
-       "      <td>strata_2: color={red}; shape={square, triangle...</td>\n",
+       "      <td>-1.725747</td>\n",
+       "      <td>strata_7: color={amber, teal}; shape={square, ...</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -391,11 +412,11 @@
       ],
       "text/plain": [
        "          y                                       strata_label\n",
-       "0  2.318870  strata_4: color={blue, green}; shape={circle};...\n",
-       "1  2.889915  strata_7: color={blue, green}; shape={square, ...\n",
-       "2  5.030329  strata_5: color={blue, green}; shape={circle};...\n",
-       "3  3.976025  strata_0: color={red}; shape={circle}; age={(-...\n",
-       "4  3.970116  strata_2: color={red}; shape={square, triangle..."
+       "0  7.018824  strata_5: color={amber, teal}; shape={circle};...\n",
+       "1  6.974324  strata_3: color={ruby}; shape={square, triangl...\n",
+       "2  5.598500  strata_2: color={ruby}; shape={square, triangl...\n",
+       "3  4.552813  strata_3: color={ruby}; shape={square, triangl...\n",
+       "4 -1.725747  strata_7: color={amber, teal}; shape={square, ..."
       ]
      },
      "execution_count": 5,
@@ -410,6 +431,65 @@
   },
   {
    "cell_type": "markdown",
+   "id": "0b6889a0",
+   "metadata": {},
+   "source": [
+    "### Сравнение дисперсий\n",
+    "\n",
+    "Метрики ниже подтверждают, что GenRest значительно уменьшает дисперсию относительно необработанных данных и простых одномерных страт. Сообщение `transform` сравнивает результат с исходными комбинациями всех категориальных признаков, поэтому при сильном уменьшении количества страт оно может показывать рост относительно этого ориентира."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "90f4bf50",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-10-22T15:41:08.296821Z",
+     "iopub.status.busy": "2025-10-22T15:41:08.296516Z",
+     "iopub.status.idle": "2025-10-22T15:41:08.316673Z",
+     "shell.execute_reply": "2025-10-22T15:41:08.315914Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Цельная дисперсия: 11.2831\n",
+      "Стратификация только по color: 2.3626\n",
+      "Стратификация только по shape: 2.4901\n",
+      "Стратификация только по age: 2.5067\n",
+      "Комбинации всех признаков: 0.0136\n",
+      "GenRest после объединения категорий: 0.4991\n",
+      "Понижение относительно цельной дисперсии: 95.58%\n"
+     ]
+    }
+   ],
+   "source": [
+    "from genrest.genetic_stratifier import _weighted_stratified_variance\n",
+    "\n",
+    "overall_var = data['y'].var(ddof=1)\n",
+    "color_var = _weighted_stratified_variance(data['y'], data['color'])\n",
+    "shape_var = _weighted_stratified_variance(data['y'], data['shape'])\n",
+    "age_var = _weighted_stratified_variance(data['y'], data['age'])\n",
+    "baseline_var = _weighted_stratified_variance(\n",
+    "    data['y'],\n",
+    "    data[['color', 'shape', 'age']].astype(str).agg('|'.join, axis=1),\n",
+    ")\n",
+    "algo_var = stratifier.best_score_\n",
+    "\n",
+    "print(f\"Цельная дисперсия: {overall_var:.4f}\")\n",
+    "print(f\"Стратификация только по color: {color_var:.4f}\")\n",
+    "print(f\"Стратификация только по shape: {shape_var:.4f}\")\n",
+    "print(f\"Стратификация только по age: {age_var:.4f}\")\n",
+    "print(f\"Комбинации всех признаков: {baseline_var:.4f}\")\n",
+    "print(f\"GenRest после объединения категорий: {algo_var:.4f}\")\n",
+    "print(f\"Понижение относительно цельной дисперсии: {(1 - algo_var / overall_var) * 100:.2f}%\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "ecde439d",
    "metadata": {},
    "source": [
@@ -420,24 +500,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "c283cf9e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-10-22T14:47:58.681815Z",
-     "iopub.status.busy": "2025-10-22T14:47:58.681493Z",
-     "iopub.status.idle": "2025-10-22T14:47:58.951507Z",
-     "shell.execute_reply": "2025-10-22T14:47:58.950549Z"
+     "iopub.execute_input": "2025-10-22T15:41:08.320096Z",
+     "iopub.status.busy": "2025-10-22T15:41:08.319778Z",
+     "iopub.status.idle": "2025-10-22T15:41:14.508728Z",
+     "shell.execute_reply": "2025-10-22T15:41:14.507615Z"
     }
    },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "array([ 1,  7,  5,  8, 10])"
+       "array([ 0,  6,  6,  7, 11])"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -448,8 +528,8 @@
     "    target_col='y',\n",
     "    mandatory_columns=['color'],\n",
     "    n_groups=2,\n",
-    "    generations=5,\n",
-    "    population_size=10,\n",
+    "    generations=40,\n",
+    "    population_size=25,\n",
     "    random_state=0,\n",
     ")\n",
     "inherited_algo.fit(data)\n",
@@ -467,14 +547,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "6454c55c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-10-22T14:47:58.954188Z",
-     "iopub.status.busy": "2025-10-22T14:47:58.953952Z",
-     "iopub.status.idle": "2025-10-22T14:47:58.983199Z",
-     "shell.execute_reply": "2025-10-22T14:47:58.981456Z"
+     "iopub.execute_input": "2025-10-22T15:41:14.511665Z",
+     "iopub.status.busy": "2025-10-22T15:41:14.511399Z",
+     "iopub.status.idle": "2025-10-22T15:41:14.547130Z",
+     "shell.execute_reply": "2025-10-22T15:41:14.546091Z"
     }
    },
    "outputs": [
@@ -484,10 +564,10 @@
      "text": [
       "\n",
       "Результаты трансформации с обязательными колонками:\n",
-      "  Цельная дисперсия: 2.536092\n",
-      "  Стратифицированная дисперсия по исходным комбинациям: 0.054331\n",
-      "  Стратифицированная дисперсия после объединения категорий: 0.139690\n",
-      "  Стратифицированная дисперсия по сравнению с исходной: понижения нет (рост на 157.11% относительно исходной стратифицированной дисперсии)\n"
+      "  Цельная дисперсия: 11.283086\n",
+      "  Стратифицированная дисперсия по исходным комбинациям: 0.013610\n",
+      "  Стратифицированная дисперсия после объединения категорий: 0.110075\n",
+      "  Стратифицированная дисперсия по сравнению с исходной: понижения нет (рост на 708.81% относительно исходной стратифицированной дисперсии)\n"
      ]
     },
     {
@@ -521,65 +601,65 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>green</td>\n",
+       "      <td>amber</td>\n",
        "      <td>circle</td>\n",
-       "      <td>(-7.724, 24.159]</td>\n",
-       "      <td>2.318870</td>\n",
-       "      <td>color=green; strata_1: shape={circle}; age={(-...</td>\n",
+       "      <td>(49.913, 72.161]</td>\n",
+       "      <td>7.018824</td>\n",
+       "      <td>color=amber; strata_0: shape={circle}; age={(4...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>blue</td>\n",
+       "      <td>ruby</td>\n",
        "      <td>square</td>\n",
-       "      <td>(24.159, 32.989]</td>\n",
-       "      <td>2.889915</td>\n",
-       "      <td>color=blue; strata_7: shape={square, triangle}...</td>\n",
+       "      <td>(49.913, 72.161]</td>\n",
+       "      <td>6.974324</td>\n",
+       "      <td>color=ruby; strata_6: shape={square, triangle}...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>blue</td>\n",
-       "      <td>circle</td>\n",
-       "      <td>(32.989, 60.66]</td>\n",
-       "      <td>5.030329</td>\n",
-       "      <td>color=blue; strata_5: shape={circle}; age={(24...</td>\n",
+       "      <td>ruby</td>\n",
+       "      <td>square</td>\n",
+       "      <td>(42.273, 49.913]</td>\n",
+       "      <td>5.598500</td>\n",
+       "      <td>color=ruby; strata_6: shape={square, triangle}...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td>red</td>\n",
-       "      <td>circle</td>\n",
-       "      <td>(-7.724, 24.159]</td>\n",
-       "      <td>3.976025</td>\n",
-       "      <td>color=red; strata_8: shape={circle}; age={(-7....</td>\n",
+       "      <td>ruby</td>\n",
+       "      <td>square</td>\n",
+       "      <td>(33.789, 42.273]</td>\n",
+       "      <td>4.552813</td>\n",
+       "      <td>color=ruby; strata_7: shape={square, triangle}...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td>red</td>\n",
-       "      <td>triangle</td>\n",
-       "      <td>(-7.724, 24.159]</td>\n",
-       "      <td>3.970116</td>\n",
-       "      <td>color=red; strata_10: shape={square, triangle}...</td>\n",
+       "      <td>teal</td>\n",
+       "      <td>square</td>\n",
+       "      <td>(33.789, 42.273]</td>\n",
+       "      <td>-1.725747</td>\n",
+       "      <td>color=teal; strata_11: shape={square, triangle...</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "   color     shape               age         y  \\\n",
-       "0  green    circle  (-7.724, 24.159]  2.318870   \n",
-       "1   blue    square  (24.159, 32.989]  2.889915   \n",
-       "2   blue    circle   (32.989, 60.66]  5.030329   \n",
-       "3    red    circle  (-7.724, 24.159]  3.976025   \n",
-       "4    red  triangle  (-7.724, 24.159]  3.970116   \n",
+       "   color   shape               age         y  \\\n",
+       "0  amber  circle  (49.913, 72.161]  7.018824   \n",
+       "1   ruby  square  (49.913, 72.161]  6.974324   \n",
+       "2   ruby  square  (42.273, 49.913]  5.598500   \n",
+       "3   ruby  square  (33.789, 42.273]  4.552813   \n",
+       "4   teal  square  (33.789, 42.273] -1.725747   \n",
        "\n",
        "                                    inherited_strata  \n",
-       "0  color=green; strata_1: shape={circle}; age={(-...  \n",
-       "1  color=blue; strata_7: shape={square, triangle}...  \n",
-       "2  color=blue; strata_5: shape={circle}; age={(24...  \n",
-       "3  color=red; strata_8: shape={circle}; age={(-7....  \n",
-       "4  color=red; strata_10: shape={square, triangle}...  "
+       "0  color=amber; strata_0: shape={circle}; age={(4...  \n",
+       "1  color=ruby; strata_6: shape={square, triangle}...  \n",
+       "2  color=ruby; strata_6: shape={square, triangle}...  \n",
+       "3  color=ruby; strata_7: shape={square, triangle}...  \n",
+       "4  color=teal; strata_11: shape={square, triangle...  "
       ]
      },
-     "execution_count": 7,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -604,14 +684,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "29bc7fc1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-10-22T14:47:58.985681Z",
-     "iopub.status.busy": "2025-10-22T14:47:58.985354Z",
-     "iopub.status.idle": "2025-10-22T14:47:59.253562Z",
-     "shell.execute_reply": "2025-10-22T14:47:59.252863Z"
+     "iopub.execute_input": "2025-10-22T15:41:14.550245Z",
+     "iopub.status.busy": "2025-10-22T15:41:14.550002Z",
+     "iopub.status.idle": "2025-10-22T15:41:20.202560Z",
+     "shell.execute_reply": "2025-10-22T15:41:20.201554Z"
     }
    },
    "outputs": [
@@ -621,10 +701,10 @@
      "text": [
       "\n",
       "Результаты трансформации с обязательными колонками:\n",
-      "  Цельная дисперсия: 2.536092\n",
-      "  Стратифицированная дисперсия по исходным комбинациям: 0.054331\n",
-      "  Стратифицированная дисперсия после объединения категорий: 0.139690\n",
-      "  Стратифицированная дисперсия по сравнению с исходной: понижения нет (рост на 157.11% относительно исходной стратифицированной дисперсии)\n"
+      "  Цельная дисперсия: 11.283086\n",
+      "  Стратифицированная дисперсия по исходным комбинациям: 0.013610\n",
+      "  Стратифицированная дисперсия после объединения категорий: 0.110075\n",
+      "  Стратифицированная дисперсия по сравнению с исходной: понижения нет (рост на 708.81% относительно исходной стратифицированной дисперсии)\n"
      ]
     },
     {
@@ -655,28 +735,28 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>2.318870</td>\n",
-       "      <td>color=green; strata_0: shape={circle}; age={(-...</td>\n",
+       "      <td>7.018824</td>\n",
+       "      <td>color=amber; strata_0: shape={circle}; age={(4...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>2.889915</td>\n",
-       "      <td>color=blue; strata_6: shape={square, triangle}...</td>\n",
+       "      <td>6.974324</td>\n",
+       "      <td>color=ruby; strata_6: shape={square, triangle}...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>5.030329</td>\n",
-       "      <td>color=blue; strata_4: shape={circle}; age={(24...</td>\n",
+       "      <td>5.598500</td>\n",
+       "      <td>color=ruby; strata_6: shape={square, triangle}...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td>3.976025</td>\n",
-       "      <td>color=red; strata_9: shape={circle}; age={(-7....</td>\n",
+       "      <td>4.552813</td>\n",
+       "      <td>color=ruby; strata_7: shape={square, triangle}...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td>3.970116</td>\n",
-       "      <td>color=red; strata_11: shape={square, triangle}...</td>\n",
+       "      <td>-1.725747</td>\n",
+       "      <td>color=teal; strata_11: shape={square, triangle...</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -684,14 +764,14 @@
       ],
       "text/plain": [
        "          y                                       quick_strata\n",
-       "0  2.318870  color=green; strata_0: shape={circle}; age={(-...\n",
-       "1  2.889915  color=blue; strata_6: shape={square, triangle}...\n",
-       "2  5.030329  color=blue; strata_4: shape={circle}; age={(24...\n",
-       "3  3.976025  color=red; strata_9: shape={circle}; age={(-7....\n",
-       "4  3.970116  color=red; strata_11: shape={square, triangle}..."
+       "0  7.018824  color=amber; strata_0: shape={circle}; age={(4...\n",
+       "1  6.974324  color=ruby; strata_6: shape={square, triangle}...\n",
+       "2  5.598500  color=ruby; strata_6: shape={square, triangle}...\n",
+       "3  4.552813  color=ruby; strata_7: shape={square, triangle}...\n",
+       "4 -1.725747  color=teal; strata_11: shape={square, triangle..."
       ]
      },
-     "execution_count": 8,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -702,8 +782,8 @@
     "    target_col='y',\n",
     "    mandatory_columns=['color'],\n",
     "    n_groups=2,\n",
-    "    generations=5,\n",
-    "    population_size=10,\n",
+    "    generations=40,\n",
+    "    population_size=25,\n",
     "    random_state=1,\n",
     ").fit_transform(\n",
     "    data,\n",
@@ -724,24 +804,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "7f950861",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-10-22T14:47:59.257956Z",
-     "iopub.status.busy": "2025-10-22T14:47:59.257664Z",
-     "iopub.status.idle": "2025-10-22T14:47:59.293184Z",
-     "shell.execute_reply": "2025-10-22T14:47:59.292360Z"
+     "iopub.execute_input": "2025-10-22T15:41:20.206098Z",
+     "iopub.status.busy": "2025-10-22T15:41:20.205579Z",
+     "iopub.status.idle": "2025-10-22T15:41:20.250047Z",
+     "shell.execute_reply": "2025-10-22T15:41:20.248744Z"
     }
    },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "Stratification(boundaries={'x': {'(-0.245, 0.225]': 1, '(-1.203, -0.245]': 1, '(-2.423, -1.203]': 1, '(0.225, 2.278]': 0}})"
+       "Stratification(boundaries={'x': {'(-0.657, 0.335]': 1, '(-1.7109999999999999, -0.657]': 1, '(0.335, 0.67]': 1, '(0.67, 2.379]': 0}})"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }


### PR DESCRIPTION
## Summary
- refresh the synthetic data generation so that examples and the README share a reproducible scenario with pronounced variance reduction after stratification
- extend the tutorial notebook with a variance comparison cell and updated algorithm parameters to highlight the improvement over raw data
- adjust the runnable example to load the package from the repository root and to use the new data recipe

## Testing
- jupyter nbconvert --to notebook --execute examples/tutorial.ipynb --output tutorial.ipynb
- python examples/run_example.py

------
https://chatgpt.com/codex/tasks/task_e_68f8f89a8a8c83328a3d7bbce42cd2fd